### PR TITLE
feat: Delete DXVK on non-backuped games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,3 @@
 ### Features
 
 * First release ([18f2065](https://github.com/artmakh/dxvk-version-mananger/commit/18f20658c54c57243813f57d8037932aa3d79bb4))
-
-## 1.0.0 (2025-03-23)
-
-
-### Features
-
-* First release ([fd4f737](https://github.com/artmakh/dxvk-version-mananger/commit/fd4f7371c7b1979631cc2a914d394ea34bcd5bf7))

--- a/main.js
+++ b/main.js
@@ -511,6 +511,44 @@ ipcMain.handle('restore-original-dlls', async (event, gameId) => {
   }
 });
 
+// IPC handler for checking backup existence
+ipcMain.handle('check-backup-exists', async (event, gameDir) => {
+  try {
+    console.log(`check-backup-exists IPC handler called for directory ${gameDir}`);
+    
+    // Check if backup exists
+    const exists = await dxvkManager.checkBackupExists(gameDir);
+    console.log(`Backup exists for ${gameDir}: ${exists}`);
+    
+    return exists;
+  } catch (error) {
+    console.error('Error checking backup existence:', error);
+    return false;
+  }
+});
+
+// IPC handler for removing DXVK without backup
+ipcMain.handle('remove-dxvk-from-game', async (event, gameId) => {
+  try {
+    console.log(`remove-dxvk-from-game IPC handler called for game ${gameId}`);
+    const game = steamGames.find(g => g.appid === gameId);
+    if (!game) {
+      return { success: false, message: `Game with ID ${gameId} not found` };
+    }
+    
+    // Get the metadata for the game
+    const metadata = await gameMetadata.getGameMetadata(gameId, game.name, game.path);
+    
+    // Remove DXVK DLLs without backup
+    const result = await dxvkManager.removeDxvkFromGame(game, metadata);
+    
+    return result;
+  } catch (error) {
+    console.error('Error removing DXVK from game:', error);
+    return { success: false, message: `Error removing DXVK DLLs: ${error.message}` };
+  }
+});
+
 // IPC handler for getting DXVK status for a game
 ipcMain.handle('get-game-dxvk-status', async (event, gameId) => {
   console.log(`get-game-dxvk-status IPC handler called for game ${gameId}`);

--- a/preload.js
+++ b/preload.js
@@ -27,7 +27,11 @@ contextBridge.exposeInMainWorld(
       
     // Game DXVK status
     getGameDxvkStatus: (gameId) => ipcRenderer.invoke('get-game-dxvk-status', gameId),
-    restoreOriginalDlls: (appId) => ipcRenderer.invoke('restore-original-dlls', appId)
+    restoreOriginalDlls: (game) => ipcRenderer.invoke('restore-original-dlls', game.appid),
+    
+    // New functions for enhanced DLL management
+    checkBackupExists: (gameDir) => ipcRenderer.invoke('check-backup-exists', gameDir),
+    removeDxvkFromGame: (game) => ipcRenderer.invoke('remove-dxvk-from-game', game.appid)
   }
 );
 


### PR DESCRIPTION
## Description

Added flow to delete DXVK libs from a game, when game have no backup of DLL's.

## Type of change

<!-- Please delete options that are not relevant and/or add your own -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Build or CI related changes
- [ ] Other (please describe):

## Checklist:

- [x] My PR title follows the conventional commit format (`feat: description`, `fix: description`, etc.)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
