### PR TITLE
feat: Set d3d and win exec version

### DIFF
--- a/games-metadata.js
+++ b/games-metadata.js
@@ -274,7 +274,9 @@ function createDefaultMetadata(gameInstallDir = null) {
     executable32bit: 'Unknown',
     executable64bit: 'Unknown',
     vulkanVersions: null,
-    installDir: gameInstallDir || null
+    installDir: gameInstallDir || null,
+    custom_d3d: false,
+    custom_exec: false
   };
 }
 
@@ -404,6 +406,45 @@ function cleanupUninstalledGamesMetadata(installedGames) {
   }
 }
 
+/**
+ * Save custom metadata for a game
+ * @param {string} appId The Steam app ID
+ * @param {Object} customMetadata The custom metadata to save
+ * @returns {Object} Result indicating success or failure
+ */
+async function saveCustomGameMetadata(appId, customMetadata) {
+  try {
+    console.log(`Saving custom metadata for game ${appId}:`, customMetadata);
+    
+    // Load existing metadata
+    let metadata = loadMetadataFromCache(appId);
+    
+    if (!metadata) {
+      console.log(`No existing metadata found for game ${appId}, creating default`);
+      metadata = createDefaultMetadata();
+    }
+    
+    // Merge custom metadata with existing metadata
+    Object.assign(metadata, customMetadata);
+    
+    // Save the updated metadata
+    saveMetadataToCache(appId, metadata);
+    
+    console.log(`Successfully saved custom metadata for game ${appId}`);
+    
+    return {
+      success: true,
+      message: 'Metadata saved successfully'
+    };
+  } catch (error) {
+    console.error(`Error saving custom metadata for game ${appId}:`, error);
+    return {
+      success: false,
+      message: `Error saving metadata: ${error.message}`
+    };
+  }
+}
+
 // Export functions
 module.exports = {
   initCacheDirs,
@@ -413,5 +454,6 @@ module.exports = {
   getDxvkInfoForGame,
   saveMetadataToCache,
   loadMetadataFromCache,
-  cleanupUninstalledGamesMetadata
+  cleanupUninstalledGamesMetadata,
+  saveCustomGameMetadata
 }; 

--- a/main.js
+++ b/main.js
@@ -579,3 +579,35 @@ ipcMain.handle('get-game-dxvk-status', async (event, gameId) => {
     };
   }
 });
+
+// IPC handler for saving custom game metadata
+ipcMain.handle('save-custom-game-metadata', async (event, gameId, metadataUpdates) => {
+  try {
+    console.log(`save-custom-game-metadata IPC handler called for game ${gameId}`);
+    console.log('Metadata updates:', metadataUpdates);
+    
+    if (!gameId) {
+      return { success: false, message: 'Game ID is required' };
+    }
+    
+    // Save the custom metadata
+    const result = await gameMetadata.saveCustomGameMetadata(gameId, metadataUpdates);
+    
+    // Find the game to get its name for display purpose
+    const game = steamGames.find(g => g.appid === gameId);
+    const gameName = game ? game.name : `Game ${gameId}`;
+    
+    console.log(`Custom metadata saved for ${gameName}:`, result);
+    
+    return {
+      success: result.success,
+      message: result.success ? `Successfully updated metadata for ${gameName}` : result.message
+    };
+  } catch (error) {
+    console.error(`Error saving custom metadata for game ${gameId}:`, error);
+    return { 
+      success: false, 
+      message: `Error saving custom metadata: ${error.message}` 
+    };
+  }
+});

--- a/preload.js
+++ b/preload.js
@@ -31,7 +31,11 @@ contextBridge.exposeInMainWorld(
     
     // New functions for enhanced DLL management
     checkBackupExists: (gameDir) => ipcRenderer.invoke('check-backup-exists', gameDir),
-    removeDxvkFromGame: (game) => ipcRenderer.invoke('remove-dxvk-from-game', game.appid)
+    removeDxvkFromGame: (game) => ipcRenderer.invoke('remove-dxvk-from-game', game.appid),
+    
+    // Game metadata customization
+    saveCustomGameMetadata: (gameId, metadataUpdates) => 
+      ipcRenderer.invoke('save-custom-game-metadata', gameId, metadataUpdates)
   }
 );
 

--- a/styles.css
+++ b/styles.css
@@ -195,6 +195,33 @@ h2 {
     border: 1px solid #e0e0e0;
 }
 
+/* Custom selector styles */
+.custom-selector select {
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    background-color: #fff;
+    font-size: 14px;
+    color: #333;
+    width: 100%;
+    max-width: 200px;
+    transition: border-color 0.3s;
+}
+
+.custom-selector select:hover {
+    border-color: #3498db;
+}
+
+.custom-selector select:focus {
+    outline: none;
+    border-color: #3498db;
+    box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.custom-selector select option {
+    padding: 4px;
+}
+
 /* DXVK Status Styles */
 .dxvk-status {
     margin-top: 5px;


### PR DESCRIPTION
## Description

For some games Direct3D version and Windows Executable is not set in pcgamingwiki.

Now you can select those versions for such titles manually.

## Type of change

<!-- Please delete options that are not relevant and/or add your own -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Build or CI related changes
- [ ] Other (please describe):

## Checklist:

- [x] My PR title follows the conventional commit format (`feat: description`, `fix: description`, etc.)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
