### PR TITLE
fix: Detect latest DXVK-gplasync releases from paginated GitLab API

### DIFF
--- a/src/common/dxvk-gplasync.js
+++ b/src/common/dxvk-gplasync.js
@@ -30,94 +30,118 @@ function ensureGplasyncCacheDir() {
   }
 }
 
+// Fetch a single page of the GitLab releases tree.
+// Resolves with the parsed items plus the next page number reported by GitLab
+// (null when this was the last page).
+function fetchGplasyncTreePage(page, perPage) {
+  const apiUrl =
+    'https://gitlab.com/api/v4/projects/Ph42oN%2Fdxvk-gplasync/repository/tree' +
+    `?path=releases&ref=main&per_page=${perPage}&page=${page}`;
+
+  const options = {
+    headers: {
+      'User-Agent': 'DXVK-Manager-App',
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    https
+      .get(apiUrl, options, res => {
+        let data = '';
+
+        res.on('data', chunk => {
+          data += chunk;
+        });
+
+        res.on('end', () => {
+          try {
+            const response = JSON.parse(data);
+
+            if (!Array.isArray(response)) {
+              reject(new Error('Invalid response format from GitLab API'));
+              return;
+            }
+
+            // GitLab paginates the tree listing and reports the next page in this
+            // header (empty string once the last page has been served).
+            const nextPageHeader = res.headers['x-next-page'];
+            const nextPage = nextPageHeader ? Number(nextPageHeader) : null;
+
+            resolve({ items: response, nextPage });
+          } catch (error) {
+            console.error('Error parsing GitLab API response:', error);
+            reject(error);
+          }
+        });
+      })
+      .on('error', error => {
+        console.error('Error fetching DXVK-gplasync releases:', error);
+        reject(error);
+      });
+  });
+}
+
 // Fetch DXVK-gplasync releases from GitLab
 async function fetchGplasyncReleases() {
   try {
-    // We'll use the GitLab API to get the repository files in the releases directory
-    const apiUrl =
-      'https://gitlab.com/api/v4/projects/Ph42oN%2Fdxvk-gplasync/repository/tree?path=releases&ref=main';
+    // The GitLab tree API is paginated (20 items per page by default), so we must
+    // follow every page or newer releases get silently dropped. See issue #16.
+    const perPage = 100;
+    const allItems = [];
+    let page = 1;
 
-    const options = {
-      headers: {
-        'User-Agent': 'DXVK-Manager-App',
-      },
-    };
+    while (page) {
+      const { items, nextPage } = await fetchGplasyncTreePage(page, perPage);
+      allItems.push(...items);
+      page = nextPage;
+    }
 
-    return new Promise((resolve, reject) => {
-      https
-        .get(apiUrl, options, res => {
-          let data = '';
+    // Filter for tar.gz files and extract version numbers
+    const releases = allItems
+      .filter(item => item.name.endsWith('.tar.gz') && !item.name.includes('native'))
+      .map(item => {
+        // Extract version from filename (e.g. dxvk-gplasync-v2.7.1-1.tar.gz -> v2.7.1-1).
+        // The leading "v" is optional so both historic and current naming work.
+        const versionMatch = item.name.match(/dxvk-gplasync-v?([0-9.]+(?:-[0-9]+)?)\.tar\.gz/);
 
-          res.on('data', chunk => {
-            data += chunk;
-          });
+        // Clean the version string to use as a safe directory name
+        const version = versionMatch
+          ? `v${versionMatch[1]}`
+          : item.name.replace(/\.tar\.gz$/, '');
 
-          res.on('end', () => {
-            try {
-              const response = JSON.parse(data);
+        // Get just the filename without path separators
+        const fileName = item.name;
 
-              if (Array.isArray(response)) {
-                // Filter for tar.gz files and extract version numbers
-                const releases = response
-                  .filter(item => item.name.endsWith('.tar.gz') && !item.name.includes('native'))
-                  .map(item => {
-                    // Extract version from filename (e.g., dxvk-gplasync-2.4.tar.gz -> v2.4)
-                    const versionMatch = item.name.match(
-                      /dxvk-gplasync-([0-9.]+(?:-[0-9]+)?)\.tar\.gz/
-                    );
+        // Construct the download URL
+        const downloadUrl = `https://gitlab.com/Ph42oN/dxvk-gplasync/-/raw/main/releases/${fileName}`;
 
-                    // Clean the version string to use as a safe directory name
-                    const version = versionMatch
-                      ? `v${versionMatch[1]}`
-                      : item.name.replace(/\.tar\.gz$/, '');
+        return {
+          version: version,
+          fileName: fileName,
+          name: `DXVK-gplasync ${version}`,
+          // We don't have a published date from the API, so use last commit date or current date
+          date: new Date(),
+          downloadUrl: downloadUrl,
+          isDownloaded: isGplasyncVersionDownloaded(version),
+        };
+      });
 
-                    // Get just the filename without path separators
-                    const fileName = item.name;
+    // Sort releases by version number in descending order
+    releases.sort((a, b) => {
+      const versionA = a.version.replace('v', '').split(/[.-]/).map(Number);
+      const versionB = b.version.replace('v', '').split(/[.-]/).map(Number);
 
-                    // Construct the download URL
-                    const downloadUrl = `https://gitlab.com/Ph42oN/dxvk-gplasync/-/raw/main/releases/${fileName}`;
-
-                    return {
-                      version: version,
-                      fileName: fileName,
-                      name: `DXVK-gplasync ${version}`,
-                      // We don't have a published date from the API, so use last commit date or current date
-                      date: new Date(),
-                      downloadUrl: downloadUrl,
-                      isDownloaded: isGplasyncVersionDownloaded(version),
-                    };
-                  });
-
-                // Sort releases by version number in descending order
-                releases.sort((a, b) => {
-                  const versionA = a.version.replace('v', '').split(/[.-]/).map(Number);
-                  const versionB = b.version.replace('v', '').split(/[.-]/).map(Number);
-
-                  for (let i = 0; i < Math.max(versionA.length, versionB.length); i++) {
-                    const numA = i < versionA.length ? versionA[i] : 0;
-                    const numB = i < versionB.length ? versionB[i] : 0;
-                    if (numA !== numB) {
-                      return numB - numA; // Higher version first
-                    }
-                  }
-                  return 0;
-                });
-
-                resolve(releases);
-              } else {
-                reject(new Error('Invalid response format from GitLab API'));
-              }
-            } catch (error) {
-              console.error('Error parsing GitLab API response:', error);
-              reject(error);
-            }
-          });
-        })
-        .on('error', error => {
-          console.error('Error fetching DXVK-gplasync releases:', error);
-          reject(error);
-        });
+      for (let i = 0; i < Math.max(versionA.length, versionB.length); i++) {
+        const numA = i < versionA.length ? versionA[i] : 0;
+        const numB = i < versionB.length ? versionB[i] : 0;
+        if (numA !== numB) {
+          return numB - numA; // Higher version first
+        }
+      }
+      return 0;
     });
+
+    return releases;
   } catch (error) {
     console.error('Error in fetchGplasyncReleases:', error);
     return [];

--- a/src/common/dxvk-gplasync.js
+++ b/src/common/dxvk-gplasync.js
@@ -105,9 +105,7 @@ async function fetchGplasyncReleases() {
         const versionMatch = item.name.match(/dxvk-gplasync-v?([0-9.]+(?:-[0-9]+)?)\.tar\.gz/);
 
         // Clean the version string to use as a safe directory name
-        const version = versionMatch
-          ? `v${versionMatch[1]}`
-          : item.name.replace(/\.tar\.gz$/, '');
+        const version = versionMatch ? `v${versionMatch[1]}` : item.name.replace(/\.tar\.gz$/, '');
 
         // Get just the filename without path separators
         const fileName = item.name;


### PR DESCRIPTION
Resolves #16

### Problem
The newest DXVK-gplasync releases were not showing up in the app — the list stopped at `2.6.2-1`, while `2.7-1`, `2.7.1-1`, and `3.0-1` were missing.

### Root cause
Two bugs in [`src/common/dxvk-gplasync.js`](src/common/dxvk-gplasync.js):

1. **Pagination** — the GitLab repository tree API returns only **20 items per page** by default, and the code fetched a single page. Every release past the 20th entry (i.e. the newest ones) was silently dropped. This is the bug reported in the issue.
2. **Version regex** — release filenames carry a `v` prefix (`dxvk-gplasync-v2.7.1-1.tar.gz`), but the regex required a digit immediately after `dxvk-gplasync-`. No filename matched, so versions fell back to the raw filename (`dxvk-gplasync-v2.6.2-1`). That also broke the version sort (parsed to `NaN`), leaving the order dependent on whatever the API happened to return.

### Fix
- Extracted `fetchGplasyncTreePage(page, perPage)` and loop through **all** pages, following GitLab's `x-next-page` header, with `per_page=100`.
- Made the leading `v` optional in the version regex (`dxvk-gplasync-v?([0-9.]+(?:-[0-9]+)?)`), so versions parse to clean strings like `v2.7.1-1` and sort correctly in descending order.

### Verification
- Ran `fetchGplasyncReleases()` against the live GitLab API: now returns all **23** releases (was 20), includes **v2.7.1-1**, and sorts **v3.0-1** to the top with correct display names.
- `npm run build` succeeds.
- Confirmed working manually in the running app.

### Notes
- ⚠️ Because versions now parse to `v2.7.1-1` instead of the old `dxvk-gplasync-v2.7.1-1`, the cache directory naming changes. Any gplasync versions a user already downloaded will be re-downloaded once on next use. This is harmless and the new naming matches the code's original intent.
